### PR TITLE
SP-70: Admin UI must be read-only

### DIFF
--- a/src/django_dramatiq_pg/admin.py
+++ b/src/django_dramatiq_pg/admin.py
@@ -32,6 +32,16 @@ class BackgroundJobAdmin(admin.ModelAdmin):
         ActorFilter,
         "state",
     )
+    readonly_fields = (
+        "message_id",
+        "queue_name",
+        "actor",
+        "state",
+        "mtime",
+        "message",
+        "result",
+        "result_ttl",
+    )
 
     def actor(self, obj):
         return obj.message["actor_name"]


### PR DESCRIPTION
- added readonly_fields to BackgroundJobAdmin